### PR TITLE
Update mydriver.py

### DIFF
--- a/Source Packages/pdlearn/mydriver.py
+++ b/Source Packages/pdlearn/mydriver.py
@@ -16,6 +16,9 @@ class Mydriver:
             self.options.add_argument('blink-settings=imagesEnabled=false')  # 不加载图片, 提升速度
         if nohead:
             self.options.add_argument('--headless')
+            self.options.add_argument('--disable-extensions')
+            self.options.add_argument('--disable-gpu')
+            self.options.add_argument('--no-sandbox')
         self.options.add_argument('--mute-audio')  # 关闭声音
         self.options.add_argument('--window-size=400,500')
         self.options.add_argument('--window-position=800,0')


### PR DESCRIPTION
  (unknown error: DevToolsActivePort file doesn't exist)
  (The process started from chrome location /usr/bin/google-chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
  (Driver info: chromedriver=2.46.628388 (4a34a70827ac54148e092aafb70504c4ea7ae926),platform=Linux 4.15.0-47-generic x86_64)

修改后可解决linux headless模式以上错误。